### PR TITLE
Slightly refactor the Genre evaluation

### DIFF
--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -192,7 +192,7 @@ sub init {
 		'ignoreReleaseTypes'    => 0,
 		'groupArtistAlbumsByReleaseType' => 0,
 		'showComposerReleasesbyAlbum' => 2,
-		'showComposerReleasesbyAlbumGenres' => "Classical",
+		'showComposerReleasesbyAlbumGenres' => "Classical, Klassik, Classique, Klassiek",
 		'ratingImplementation'  => 'LOCAL_RATING_STORAGE',
 		# Server Settings - FileTypes
 		'disabledextensionsaudio'    => '',


### PR DESCRIPTION
This isn't as much an improvement as I hoped :). And I see that you've taken inspiration from some of my own code...

Anyway: I made the lookup slightly less verbose. And I created a hash with the genres to prevent the repeated uppercasing and splitting of the genres list. And looking up a value in a hash is much more efficient then repeatedly grepping a list. Though this overhead is neglectable here anyway.

And then I moved that `COMPOSERALBUM` down, to avoid the overwriting of the `role_ids`.