### PR TITLE
Need to clean up CUE based tags one more time

### DIFF
--- a/Slim/Formats.pm
+++ b/Slim/Formats.pm
@@ -275,13 +275,7 @@ sub readTags {
 
 	main::DEBUGLOG && $isDebug && $log->debug("Report for $file:");
 
-	# XXX: can Audio::Scan make these regexes unnecessary?
-
 	sanitizeTagValues($tags, $file);
-
-	if (scalar (keys %tagCache) > 50) {
-		%tagCache = ();
-	}
 
 	return $tags;
 }
@@ -345,6 +339,10 @@ sub sanitizeTagValues {
 		}
 
 		main::DEBUGLOG && $log->is_debug && $value && $log->debug(". $tag : $value");
+	}
+
+	if (scalar (keys %tagCache) > 50) {
+		%tagCache = ();
 	}
 }
 

--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -133,6 +133,10 @@ sub getTag {
 	# suck in metadata for all these tags
 	my $items = $class->_getSubFileTags($s, $tracks);
 
+	foreach (values %$tracks) {
+		Slim::Formats::sanitizeTagValues($_, $file);
+	}
+
 	# fallback if we can't parse metadata
 	if ( $items < 1 ) {
 		logWarning("Unable to find metadata for tracks referenced by cuesheet: [$file]");
@@ -347,10 +351,6 @@ sub _getSubFileTags {
 
 	# parse cuesheet stuffed into a vorbis comment
 	$items = $class->_getCUEinVCs($s, $tracks);
-	return $items if $items > 0;
-
-	# try parsing stacked vorbis comments
-	$items = $class->_getStackedVCs($s, $tracks);
 	return $items if $items > 0;
 
 	# This won't yield good results - but without it, we regress from 6.0.2
@@ -789,107 +789,6 @@ sub _getCUEinVCs {
 	}
 
 	return $items;
-}
-
-sub _getStackedVCs {
-	my ($class, $s, $tracks) = @_;
-
-	my $items  = 0;
-
-	# XXX: can't support this using Audio::Scan, this is a stupid tag scheme anyway!
-	return 0;
-
-=pod
-	# parse "stacked" vorbis comments
-	# this is tricky when it comes to matching which groups belong together
-	# particularly for various artist, or multiple album compilations.
-	# this as also not terribly efficent, so it's not our first choice.
-
-	# here's a simple example of the sort of thing we're trying to work with
-	#
-	# ARTIST=foo
-	# ALBUM=bar
-	# TRACKNUMBER=1
-	# TITLE=baz
-	# TRACKNUMBER=2
-	# TITLE=something
-
-	# grab the raw comments for parsing
-	my $rawTags = $flac->{'rawTags'};
-
-	# grab the cuesheet for reference
-	my $cuesheet = $flac->cuesheet();
-
-	# validate number of TITLE tags against number of
-	# tracks in the cuesheet
-	my $titletags = 0;
-	my $cuetracks = 0;
-
-	for my $tag (@$rawTags) {
-		$titletags++ if $tag =~ /^\s*TITLE=/i;
-	}
-
-	for my $track (@$cuesheet) {
-		$cuetracks++ if $track =~ /^\s*TRACK/i;
-	}
-
-	return 0 unless $titletags == $cuetracks;
-
-
-	# ok, let's see which tags apply to which tracks
-
-	my $tempTags = {};
-	my $defaultTags = {};
-
-	$class->_addInfoTags($flac, $defaultTags);
-
-	for my $tag (@$rawTags) {
-
-		# Match the key and value
-		if ($tag =~ /^(.*?)=(.*?)[\r\n]*$/) {
-
-			# Make the key uppercase
-			my $tkey  = uc($1);
-			my $value = $2;
-
-			# use duplicate detection to find track boundries
-			# retain file wide values as defaults
-			if (defined $tempTags->{$tkey}) {
-				$items++;
-				my %merged = (%{$defaultTags}, %{$tempTags});
-				$defaultTags = \%merged;
-				$tempTags = {};
-
-				# set the tags on the track
-				%{$tracks->{$items}} = (%{$tracks->{$items}}, %{$defaultTags});
-
-				$class->_doTagMapping($tracks->{$items});
-
-				if (!exists $tracks->{$items}->{'TRACKNUM'}) {
-					$tracks->{$items}->{'TRACKNUM'} = $items;
-				}
-
-			}
-
-			$tempTags->{$tkey} = $value;
-
-			main::DEBUGLOG && logger('formats.playlists')->debug("    $tkey: $value");
-		}
-	}
-
-	# process the final track
-	$items++;
-
-	%{$tracks->{$items}} = (%{$tracks->{$items}}, %{$defaultTags}, %{$tempTags});
-
-	$class->_doTagMapping($tracks->{$items});
-
-	if (!exists $tracks->{$items}->{'TRACKNUM'}) {
-		$tracks->{$items}->{'TRACKNUM'} = $items;
-	}
-
-	return $items;
-=cut
 }
 
 =head2 findFrameBoundaries( $fh, $offset, $time )

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -912,7 +912,8 @@ sub _createOrUpdateAlbum {
 	my $disc      = $attributes->{DISC};
 	my $discc     = $attributes->{DISCC};
 	# Bug 10583 - Also check for MusicBrainz Album Id
-	my $brainzId  = $attributes->{MUSICBRAINZ_ALBUM_ID}[0]; # Surely there is only one MB album id!
+	# Surely there is only one MB album id!
+	my $brainzId  = ref $attributes->{MUSICBRAINZ_ALBUM_ID} ? $attributes->{MUSICBRAINZ_ALBUM_ID}[0] : $attributes->{MUSICBRAINZ_ALBUM_ID};
 	my $extId     = $attributes->{EXTID} || $attributes->{ALBUM_EXTID};
 
 	# if we have a disc number from an online service, default disc count to 1


### PR DESCRIPTION
The FLAC parser seems to further scan CUE sheets - don't ask me why. But the MB tags seem to only be added here. Therefore we'll have to go over the track list one more time.

I also moved the `%tagCache` cleanup to the sanitizer, as it's the only place where it's being used.

And I still left the safeguard in `Schema.pm`.

And then I removed some unused code from the FLAC parser. Because it had been commented out for about a decade...