### PR TITLE
Replace swap with separate display_artist storage

### DIFF
--- a/Changelog9.html
+++ b/Changelog9.html
@@ -8,6 +8,7 @@
 		<li><a href="https://github.com/LMS-Community/slimserver/issues/1286">#1286</a> - Display album cover for AudioAddict stations (inspired by some work by @mcduman)</li>
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1541">#1541</a> - Add per-player timezone support: players can now display date and time, and fire alarms, in their own timezone rather than the server's. (@boudekerk)</li>
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1546">#1546</a> - Add "Default Adjustment for Local Tracks" player option. (@SamInPgh)</li>
+		<li><a href="https://github.com/LMS-Community/slimserver/issues/1555">#1555</a> - Store display_artist from ALBUMARTIST/ARTIST tags separately from individual contributors. Optional use of ALBUMARTISTS/ARTISTS plural tags for contributor creation. (@Rouzax)</li>
 	</ul>
 	<br />
 

--- a/HTML/EN/settings/server/behavior.html
+++ b/HTML/EN/settings/server/behavior.html
@@ -195,6 +195,15 @@
 		</select>
 	[% END %]
 
+	[% WRAPPER setting title="SETUP_USEPLURALARTISTTAGS" desc="SETUP_USEPLURALARTISTTAGS_DESC"%]
+		<select class="stdedit" name="pref_usePluralArtistTags" id="usePluralArtistTags">
+
+			<option [% IF NOT prefs.pref_usePluralArtistTags %]selected [% END %]value="0">[% 'SETUP_USEPLURALARTISTTAGS_0' | string %]</option>
+			<option [% IF prefs.pref_usePluralArtistTags %]selected [% END %]value="1">[% 'SETUP_USEPLURALARTISTTAGS_1' | string %]</option>
+
+		</select>
+	[% END %]
+
 	[% WRAPPER setting title="SETUP_YEARMENU" desc="SETUP_YEARMENU_DESC"%]
 		<select class="stdedit" name="pref_onlyAlbumYears" id="onlyAlbumYears">
 

--- a/SQL/SQLite/schema_27_up.sql
+++ b/SQL/SQLite/schema_27_up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE albums ADD display_artist blob;
+ALTER TABLE tracks ADD display_artist blob;

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -647,9 +647,7 @@ sub albumsQuery {
 		# We need the main albums.contributor name for favorites, so always do this join unless getting count only.
 		$sql .= 'JOIN contributors ON contributors.id = albums.contributor ';
 		$c->{'contributors.name'} = 1;
-		$c->{'albums.label'} = 1;
-#		$sql .= 'LEFT JOIN contributor_display ON albums.display_contributor = contributor_display.id ';
-#		$c->{'contributor_display.name'} = 1;
+		$c->{'albums.display_artist'} = 1;
 	}
 
 	if ( $tags =~ /s/ ) {
@@ -840,8 +838,7 @@ sub albumsQuery {
 			utf8::decode( $c->{'composer.name'} ) if exists $c->{'composer.name'};
 			utf8::decode( $c->{'tracks.performance'} ) if exists $c->{'tracks.performance'};
 			utf8::decode( $c->{'contributors.name'} ) if exists $c->{'contributors.name'};
-#			utf8::decode( $c->{'contributor_display.name'} ) if exists $c->{'contributor_display.name'};
-			utf8::decode( $c->{'albums.label'} ) if exists $c->{'albums.label'};
+			utf8::decode( $c->{'albums.display_artist'} ) if exists $c->{'albums.display_artist'};
 			$request->addResultLoop($loopname, $chunkCount, 'id', $c->{'albums.id'});
 			$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'work_id', $c->{'tracks.work'});
 			$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'work_name', $c->{'works.title'});
@@ -904,9 +901,8 @@ sub albumsQuery {
 			#Don't use albums.contributor to set artist_id/artist for Works, it may well be completely wrong!
 			if ( !$work ) {
 				$tags =~ /S/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artist_id', $c->{'albums.contributor'});
-				$tags =~ /a/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artist', $c->{'contributors.name'});
-#				$tags =~ /a/ && $c->{'contributor_display.name'} && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'display_artist', $c->{'contributor_display.name'});
-				$tags =~ /a/ && $c->{'albums.label'} && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'display_artist', $c->{'albums.label'});
+				$tags =~ /a/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artist', $c->{'albums.display_artist'} || $c->{'contributors.name'});
+				$tags =~ /a/ && $c->{'albums.display_artist'} && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'display_artist', $c->{'albums.display_artist'});
 				$tags =~ /4/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'portraitid', $c->{'contributors.portraitid'});
 			}
 
@@ -5799,9 +5795,9 @@ sub _songDataFromHash {
 					$returnHash{$role} = $res->{$role};
 				}
 			}
-			# also return contributor_display.name
-#			$returnHash{'display_artist'} = $res->{'contributor_display.name'} if $res->{'contributor_display.name'};
-			$returnHash{'display_artist'} = $res->{'albums.label'} if $res->{'albums.label'};
+
+			my $da = $res->{'tracks.display_artist'} || $res->{'albums.display_artist'};
+			$returnHash{display_artist} = $da if $da;
 		}
 		elsif ( $tag eq 'S' ) {
 			for my $role ( @contributorRoles ) {
@@ -6402,13 +6398,6 @@ sub _getTagDataForTracks {
 		}
 	};
 
-#	my $join_contributor_display = sub {
-#		if ( $sql !~ /JOIN contributor_display/ ) {
-#		$join_albums->();
-#			$sql .= 'LEFT JOIN contributor_display ON albums.display_contributor = contributor_display.id ';
-#		}
-#	};
-
 	if ( my $year = $args->{year} ) {
 		push @{$w}, 'tracks.year = ?';
 		push @{$p}, $year;
@@ -6514,13 +6503,6 @@ sub _getTagDataForTracks {
 	$tags =~ /[as]/ && do {
 		$join_contributors->();
 		$c->{'contributors.name'} = 1 if $tags =~ /a/;
-		
-#		$join_contributor_display->();
-#		$c->{'contributor_display.name'} = 1;
-		$join_albums->();
-		$c->{'albums.label'} = 1;
-		
-		
 
 		# only albums on which the contributor has a specific role?
 		my @roles;
@@ -6548,6 +6530,12 @@ sub _getTagDataForTracks {
 	$tags =~ /4/ && do {
 		$join_contributors->();
 		$c->{'contributors.portraitid'} = 1;
+	};
+
+	$tags =~ /[aA]/ && do {
+		$join_albums->();
+		$c->{'albums.display_artist'} = 1;
+		$c->{'tracks.display_artist'} = 1;
 	};
 
 	$tags =~ /l/ && do {
@@ -6680,11 +6668,12 @@ sub _getTagDataForTracks {
 			utf8::decode( $c->{'tracks.lyrics'} ) if exists $c->{'tracks.lyrics'};
 			utf8::decode( $c->{'albums.title'} ) if exists $c->{'albums.title'};
 			utf8::decode( $c->{'contributors.name'} ) if exists $c->{'contributors.name'};
-			utf8::decode( $c->{'contributor_display.name'} ) if exists $c->{'contributor_display.name'};
 			utf8::decode( $c->{'genres.name'} ) if exists $c->{'genres.name'};
 			utf8::decode( $c->{'comments.value'} ) if exists $c->{'comments.value'};
 			utf8::decode( $c->{'tracks.discsubtitle'}) if exists $c->{'tracks.discsubtitle'};
 			utf8::decode( $c->{'tracks.grouping'}) if exists $c->{'tracks.grouping'};
+			utf8::decode( $c->{'albums.display_artist'}) if exists $c->{'albums.display_artist'};
+			utf8::decode( $c->{'tracks.display_artist'}) if exists $c->{'tracks.display_artist'};
 		}
 
 		my $id = $c->{'tracks.id'};

--- a/Slim/Plugin/FullTextSearch/Plugin.pm
+++ b/Slim/Plugin/FullTextSearch/Plugin.pm
@@ -35,7 +35,8 @@ use constant SQL_CREATE_TRACK_ITEM => q{
 		UNIQUE_TOKENS(LOWER(IFNULL(tracks.title, '')) || ' ' || IFNULL(tracks.titlesearch, '') || ' ' || IFNULL(tracks.customsearch, '')),
 		-- weight 5
 		UNIQUE_TOKENS(IFNULL(tracks.year, '') || ' ' || GROUP_CONCAT(albums.title, ' ') || ' ' || GROUP_CONCAT(albums.titlesearch, ' ') || ' '
-			|| GROUP_CONCAT(genres.name, ' ') || ' ' || GROUP_CONCAT(genres.namesearch, ' ')),
+			|| GROUP_CONCAT(genres.name, ' ') || ' ' || GROUP_CONCAT(genres.namesearch, ' ') || ' '
+			|| IFNULL(tracks.display_artist, '') || ' ' || IFNULL(albums.display_artist, '')),
 		-- weight 3 - contributors create multiple hits, therefore only w3
 		UNIQUE_TOKENS(CONCAT_CONTRIBUTOR_ROLE(tracks.id, GROUP_CONCAT(contributor_track.contributor, ','), 'contributor_track') || ' '
 			|| IGNORE_CASE(comments.value) || ' ' || IGNORE_CASE(tracks.lyrics) || ' ' || IFNULL(tracks.content_type, '') || ' '
@@ -112,7 +113,7 @@ use constant SQL_CREATE_ALBUM_ITEM => qq{
 		UNIQUE_TOKENS(LOWER(IFNULL(albums.title, '')) || ' ' || IFNULL(albums.titlesearch, '') || ' ' || IFNULL(albums.customsearch, '') || ' '
 		|| IFNULL((SELECT GROUP_CONCAT(wt,' ') FROM (SELECT DISTINCT works.titlesearch wt FROM tracks JOIN works ON tracks.work = works.id WHERE tracks.album = albums.id) ), ' ') ),
 		-- weight 5
-		IFNULL(albums.year, ''),
+		UNIQUE_TOKENS(IFNULL(albums.year, '') || ' ' || IFNULL(albums.display_artist, '')),
 		-- weight 3
 		UNIQUE_TOKENS(CONCAT_CONTRIBUTOR_ROLE(albums.id, GROUP_CONCAT(contributor_album.contributor, ','), 'contributor_album')),
 		-- weight 1

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -930,7 +930,7 @@ sub _objForDbUrl {
 }
 
 sub _createOrUpdateAlbum {
-	my ($self, $attributes, $trackColumns, $isCompilation, $contributorId, $hasAlbumArtist, $create, $track, $basename, $aaDisplayID) = @_;
+	my ($self, $attributes, $trackColumns, $isCompilation, $contributorId, $hasAlbumArtist, $create, $track, $basename, $albumDisplayArtist) = @_;
 
 	my $dbh = $self->dbh;
 
@@ -1296,8 +1296,7 @@ sub _createOrUpdateAlbum {
 	}
 
 	$albumHash->{musicbrainz_id} = $attributes->{MUSICBRAINZ_ALBUM_ID};
-#	$albumHash->{display_contributor} = $aaDisplayID;
-	$albumHash->{label} = $aaDisplayID;
+	$albumHash->{display_artist} = $albumDisplayArtist if $albumDisplayArtist;
 
 	# Handle album gain tags.
 	for my $gainTag ( qw(REPLAYGAIN_ALBUM_GAIN REPLAYGAIN_ALBUM_PEAK) ) {
@@ -1307,6 +1306,7 @@ sub _createOrUpdateAlbum {
 		# Bug 8034, this used to not change gain/peak values if they were already set,
 		# bug we do want to update album gain tags if they are changed.
 		if ( $attributes->{$gainTag} ) {
+			$attributes->{$gainTag} = $attributes->{$gainTag}[0] if ref $attributes->{$gainTag} eq 'ARRAY';
 			$attributes->{$gainTag} =~ s/\s*dB//gi;
 			$attributes->{$gainTag} =~ s/\s//g;  # bug 15965
 			$attributes->{$gainTag} =~ s/,/\./g; # bug 6900, change comma to period
@@ -1708,18 +1708,28 @@ sub _newTrack {
 		$LAST_ERROR = 'Track is DRM-protected';
 		return;
 	}
-###
-	if ( $attributeHash->{ALBUMARTIST} && $attributeHash->{ALBUMARTISTS} ) {
-		my $temp = $attributeHash->{ALBUMARTISTS};
-		$attributeHash->{ALBUMARTISTS} = $attributeHash->{ALBUMARTIST};
-		$attributeHash->{ALBUMARTIST} = $temp;
+
+	# Capture display strings from singular tags before _preCheckAttributes defers them.
+	# For multi-value tags, the first entry is the display string.
+	# When only the plural tag exists, concatenate its entries as the display string.
+	my $albumDisplayArtist;
+	if ( $attributeHash->{ALBUMARTIST} ) {
+		$albumDisplayArtist = ref $attributeHash->{ALBUMARTIST} eq 'ARRAY'
+			? $attributeHash->{ALBUMARTIST}->[0]
+			: $attributeHash->{ALBUMARTIST};
+	} elsif ( $attributeHash->{ALBUMARTISTS} && ref $attributeHash->{ALBUMARTISTS} eq 'ARRAY' ) {
+		$albumDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ALBUMARTISTS}});
 	}
-	if ( $attributeHash->{ARTIST} && $attributeHash->{ARTISTS} ) {
-		my $temp = $attributeHash->{ARTISTS};
-		$attributeHash->{ARTISTS} = $attributeHash->{ARTIST};
-		$attributeHash->{ARTIST} = $temp;
+
+	my $trackDisplayArtist;
+	if ( $attributeHash->{ARTIST} ) {
+		$trackDisplayArtist = ref $attributeHash->{ARTIST} eq 'ARRAY'
+			? $attributeHash->{ARTIST}->[0]
+			: $attributeHash->{ARTIST};
+	} elsif ( $attributeHash->{ARTISTS} && ref $attributeHash->{ARTISTS} eq 'ARRAY' ) {
+		$trackDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ARTISTS}});
 	}
-###
+
 	($attributeHash, $deferredAttributes) = $self->_preCheckAttributes({
 		'url'        => $url,
 		'attributes' => $attributeHash,
@@ -1806,26 +1816,12 @@ sub _newTrack {
 	# Walk through the valid contributor roles, adding them to the database.
 	my $contributors = $self->_mergeAndCreateContributors($deferredAttributes, $isCompilation, 1);
 
-###
-	my $aaDisplayID = $deferredAttributes->{ALBUMARTISTS};
-#	my $aaDisplayID;
-#	if ( $deferredAttributes->{ALBUMARTISTS} ) {
-#		my $contributor_display_sth = $self->dbh->prepare_cached('SELECT id FROM contributor_display WHERE name = ?');
-#		$contributor_display_sth->execute($deferredAttributes->{ALBUMARTISTS});
-#		($aaDisplayID) = $contributor_display_sth->fetchrow_array;
-#		$contributor_display_sth->finish;
-#		if ( !$aaDisplayID ) {
-#			my $sth_insert = $self->dbh->prepare_cached("INSERT INTO contributor_display (name) VALUES (?)");
-#			$sth_insert->execute( $deferredAttributes->{ALBUMARTISTS} );
-#			$aaDisplayID = $self->dbh->last_insert_id(undef, undef, undef, undef);
-#		}
-#	}
-###
-
 	# Set primary_artist for the track
 	if ( my $artist = $contributors->{ARTIST} || $contributors->{TRACKARTIST} ) {
 		$columnValueHash{primary_artist} = $artist->[0];
 	}
+
+	$columnValueHash{display_artist} = $trackDisplayArtist if $trackDisplayArtist;
 
 	### Create Work rows
 	my $workID;
@@ -1862,7 +1858,7 @@ sub _newTrack {
 		1,																		# create
 		undef,																	# Track
 		$dirname,
-		$aaDisplayID,
+		$albumDisplayArtist,
 	);
 
 	### Create Track row
@@ -1871,7 +1867,7 @@ sub _newTrack {
 	$trackId = $self->_createTrack(\%columnValueHash, \%persistentColumnValueHash, $source);
 
 	### Create ContributorTrack & ContributorAlbum rows
-	$self->_createContributorRoleRelationships($contributors, $trackId, $albumId, $aaDisplayID);
+	$self->_createContributorRoleRelationships($contributors, $trackId, $albumId);
 
 	### Create Genre rows
 	$self->_createGenre($deferredAttributes->{'GENRE'}, $trackId, 1);
@@ -2027,6 +2023,24 @@ sub updateOrCreateBase {
 			$attributeHash = { %{Slim::Formats->readTags($url)}, %$attributeHash  };
 		}
 
+		my $albumDisplayArtist;
+		if ( $attributeHash->{ALBUMARTIST} ) {
+			$albumDisplayArtist = ref $attributeHash->{ALBUMARTIST} eq 'ARRAY'
+				? $attributeHash->{ALBUMARTIST}->[0]
+				: $attributeHash->{ALBUMARTIST};
+		} elsif ( $attributeHash->{ALBUMARTISTS} && ref $attributeHash->{ALBUMARTISTS} eq 'ARRAY' ) {
+			$albumDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ALBUMARTISTS}});
+		}
+
+		my $trackDisplayArtist;
+		if ( $attributeHash->{ARTIST} ) {
+			$trackDisplayArtist = ref $attributeHash->{ARTIST} eq 'ARRAY'
+				? $attributeHash->{ARTIST}->[0]
+				: $attributeHash->{ARTIST};
+		} elsif ( $attributeHash->{ARTISTS} && ref $attributeHash->{ARTISTS} eq 'ARRAY' ) {
+			$trackDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ARTISTS}});
+		}
+
 		my $deferredAttributes;
 		($attributeHash, $deferredAttributes) = $self->_preCheckAttributes({
 			'url'        => $url,
@@ -2073,13 +2087,16 @@ sub updateOrCreateBase {
 		}
 		$trackPersistent->update() if blessed($trackPersistent);
 
+		$track->set_column('display_artist', $trackDisplayArtist) if $trackDisplayArtist;
+
 		# _postCheckAttributes does an update
 		if (!$playlist) {
 
 			$self->_postCheckAttributes({
-				'track'      => $track,
-				'attributes' => $deferredAttributes,
-				'integrateRemote' => $integrateRemote
+				'track'              => $track,
+				'attributes'         => $deferredAttributes,
+				'integrateRemote'    => $integrateRemote,
+				'albumDisplayArtist' => $albumDisplayArtist,
 			});
 		}
 
@@ -2832,6 +2849,7 @@ sub _preCheckAttributes {
 	# Bug: 2605 - Get URL out of the attributes - some programs, and
 	# services such as www.allofmp3.com add it.
 	if ($attributes->{'URL'}) {
+		$attributes->{'URL'} = $attributes->{'URL'}[0] if ref $attributes->{'URL'} eq 'ARRAY';
 
 		push @$rawcomments, delete $attributes->{'URL'};
 	}
@@ -2952,6 +2970,7 @@ sub processReplayGainTags {
 		   $shortTag =~ s/^REPLAYGAIN_TRACK_(\w+)$/REPLAY_$1/;
 
 		if (defined $attributes->{$gainTag}) {
+			$attributes->{$gainTag} = $attributes->{$gainTag}[0] if ref $attributes->{$gainTag} eq 'ARRAY';
 
 			$attributes->{$shortTag} = delete $attributes->{$gainTag};
 			$attributes->{$shortTag} =~ s/\s*dB//gi;
@@ -3050,9 +3069,10 @@ sub _postCheckAttributes {
 
 	my $isDebug = main::DEBUGLOG && $log->is_debug;
 
-	my $track      = $args->{'track'};
-	my $attributes = $args->{'attributes'};
-	my $create     = $args->{'create'} || 0;
+	my $track              = $args->{'track'};
+	my $attributes         = $args->{'attributes'};
+	my $create             = $args->{'create'} || 0;
+	my $albumDisplayArtist = $args->{'albumDisplayArtist'};
 
 	# Don't bother with directories / lnks. This makes sure "No Artist",
 	# etc don't show up if you don't have any.
@@ -3114,10 +3134,12 @@ sub _postCheckAttributes {
 	my $albumId = $self->_createOrUpdateAlbum($attributes,
 		\%cols,																	# trackColumns
 		$isCompilation,
-		$artist->[0],	                                          # primary contributor-id
+		$artist->[0],															# primary contributor-id
 		defined $contributors->{'ALBUMARTIST'}->[0] ? 1 : 0,					# hasAlbumArtist
 		$create,																# create
 		$track,																	# Track
+		undef,																	# basename
+		$albumDisplayArtist,
 	);
 
 	# Don't add an album to container tracks - See bug 2337
@@ -3160,6 +3182,22 @@ sub _mergeAndCreateContributors {
 			main::DEBUGLOG && $isDebug && $log->debug(sprintf("-- Contributor '%s' of role 'ARTIST' transformed to role 'TRACKARTIST'",
 				$attributes->{'TRACKARTIST'},
 			));
+		}
+	}
+
+	# When plural tags (ALBUMARTISTS/ARTISTS) are present and the preference
+	# is enabled, use their entries as the sole contributor source for that
+	# role. The singular tag value (display string) is already stored in
+	# display_artist columns.
+	if ( $prefs->get('usePluralArtistTags') ) {
+		for my $pair ( ['ALBUMARTISTS', 'ALBUMARTIST'], ['ARTISTS', $attributes->{TRACKARTIST} ? 'TRACKARTIST' : 'ARTIST'] ) {
+			my ($plural, $singular) = @$pair;
+			next unless $attributes->{$plural} && ref $attributes->{$plural} eq 'ARRAY';
+
+			my @individuals = grep { defined $_ && $_ ne '' } @{$attributes->{$plural}};
+			next unless @individuals;
+
+			$attributes->{$singular} = \@individuals;
 		}
 	}
 
@@ -3222,7 +3260,7 @@ sub _mergeAndCreateContributors {
 
 sub _createContributorRoleRelationships {
 
-	my ($self, $contributors, $trackId, $albumId, $aaDisplayID) = @_;
+	my ($self, $contributors, $trackId, $albumId) = @_;
 
 	if (!keys %$contributors) {
 		main::DEBUGLOG && $log->debug('Attempt to set empty contributor set for trackid=', $trackId);
@@ -3262,14 +3300,7 @@ sub _createContributorRoleRelationships {
 		VALUES
 		(?, ?, ?)
 	} );
-#	my $sth_album_display = $self->dbh->prepare_cached( qq{
-#		REPLACE INTO contributor_album_display
-#		(contributor_display, contributor, album)
-#		VALUES
-#		(?, ?, ?)
-#	} ) if $aaDisplayID;
 
-Slim::Utils::Log::logError("DK \$contributors=" . Data::Dump::dump($contributors));
 	while (my ($role, $contributorList) = each %{$contributors}) {
 		my $roleId = Slim::Schema::Contributor->typeToRole($role);
 		for my $contributor (@{$contributorList}) {
@@ -3280,9 +3311,6 @@ Slim::Utils::Log::logError("DK \$contributors=" . Data::Dump::dump($contributors
 
 			# The following is retained at present to add mappings for BMF, entries created will be deleted in the optimise phase
 			$sth_album->execute( $roleId, $contributor, $albumId );
-#			if ( $aaDisplayID && $role eq 'ALBUMARTIST' ) {
-#				$sth_album_display->execute( $aaDisplayID, $contributor, $albumId );
-#			}
 		}
 	}
 }

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -173,6 +173,7 @@ sub init {
 		'autoDownloadUpdate'    => sub { $os->canAutoUpdate() },
 		'noGenreFilter'         => 0,
 		'noRoleFilter'          => 0,
+		'usePluralArtistTags'   => 0,
 		'searchSubString'       => 0,
 		'ignoredarticles'       => "The El La Los Las Le Les",
 		'splitList'             => ';',

--- a/strings.txt
+++ b/strings.txt
@@ -8703,6 +8703,18 @@ SETUP_NOROLEFILTER_DESC
 	SV	När du bläddrar genom "Artister" kan du filtrera så att bara album och låtar som matchar den valda rollen ("ALBUMARTIST", "COMPOSER", etc.) visas.
 	ZH_CN	在浏览艺术家时，可以过滤并只显示和所选角色匹配的专辑和音轨（例如，ALBUMARTIST，COMPOSER等）。
 
+SETUP_USEPLURALARTISTTAGS
+	EN	Use Plural Artist Tags
+
+SETUP_USEPLURALARTISTTAGS_DESC
+	EN	When enabled, the scanner uses ALBUMARTISTS and ARTISTS tags (plural) as the authoritative source for individual contributors. This produces clean contributor entries without joined display strings. Requires a rescan after changing. Tags written by Picard, SongKong, and other modern taggers are supported.
+
+SETUP_USEPLURALARTISTTAGS_0
+	EN	Disabled
+
+SETUP_USEPLURALARTISTTAGS_1
+	EN	Enabled
+
 SETUP_ROLESINARTISTS
 	CS	Interpret skladby, Skladatel, Skupina a Orchestr v Interpretech
 	DA	Nummerets kunstner, Komponist, band og orkester i Kunstnere


### PR DESCRIPTION
## Summary

Replaces the tag-swap mechanism with dedicated `display_artist` columns on albums and tracks. Stores ALBUMARTIST/ARTIST tag values directly as display strings. When the opt-in preference is enabled, ALBUMARTISTS/ARTISTS plural tags are used as the sole contributor source.

## Changes

- **Schema:** `display_artist` columns on albums and tracks (schema_27_up.sql). Replaces `albums.label` placeholder.
- **Scanner:** Captures display strings before `_preCheckAttributes`, stores in columns. Both create and update paths handled (fixes the rescan bug).
- **Queries:** `COALESCE(display_artist, contributors.name)` for the `a` tag artist field. `display_artist` returned alongside existing fields. UTF-8 decode added. No breaking API changes.
- **Preference:** `usePluralArtistTags` in Settings > Behavior. Off by default. When on, plural tags replace singular for contributor creation.
- **Search:** `display_artist` added to fulltext index.
- **Cleanup:** Removes swap blocks, `albums.label` usage, commented-out `contributor_display` tables, debug `logError`.

## Why replace the swap

- Rescan path skipped the swap (only in `_newTrack`, not update path)
- Scenario 3 data loss when ARTISTS has fewer entries than ARTIST
- Display string detection heuristic proved unsolvable across languages

Flat columns match the Navidrome/OpenSubsonic model where `displayArtist` is a simple string field.

## Testing

Verified with 52 automated tests covering fresh install, schema upgrade (26 to 27), album rescan after retagging, preference toggle, regression on 18 existing fixture patterns, and API contract validation.

## What is kept from your branch

- `display_artist` field name in the API
- `show_artist_list` popup concept (Material PR to follow)
- The contributor_album structure