### PR TITLE
Functional changes for display_artist on 3NF schema

### DIFF
--- a/Changelog9.html
+++ b/Changelog9.html
@@ -9,6 +9,7 @@
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1541">#1541</a> - Add per-player timezone support: players can now display date and time, and fire alarms, in their own timezone rather than the server's. (@boudekerk)</li>
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1546">#1546</a> - Add "Default Adjustment for Local Tracks" player option. (@SamInPgh)</li>
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1564">#1564</a> - Add Dismiss option to Jive alarm popup (@boudekerk)</li>
+		<li><a href="https://github.com/LMS-Community/slimserver/issues/1555">#1555</a> - Store display_artist from ALBUMARTIST/ARTIST tags separately from individual contributors. Optional use of ALBUMARTISTS/ARTISTS plural tags for contributor creation. (@Rouzax, @darrell-k)</li>
 	</ul>
 	<br />
 

--- a/HTML/EN/settings/server/behavior.html
+++ b/HTML/EN/settings/server/behavior.html
@@ -195,6 +195,15 @@
 		</select>
 	[% END %]
 
+	[% WRAPPER setting title="SETUP_USEPLURALARTISTTAGS" desc="SETUP_USEPLURALARTISTTAGS_DESC"%]
+		<select class="stdedit" name="pref_usePluralArtistTags" id="usePluralArtistTags">
+
+			<option [% IF NOT prefs.pref_usePluralArtistTags %]selected [% END %]value="0">[% 'SETUP_USEPLURALARTISTTAGS_0' | string %]</option>
+			<option [% IF prefs.pref_usePluralArtistTags %]selected [% END %]value="1">[% 'SETUP_USEPLURALARTISTTAGS_1' | string %]</option>
+
+		</select>
+	[% END %]
+
 	[% WRAPPER setting title="SETUP_YEARMENU" desc="SETUP_YEARMENU_DESC"%]
 		<select class="stdedit" name="pref_onlyAlbumYears" id="onlyAlbumYears">
 

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -5797,8 +5797,8 @@ sub _songDataFromHash {
 					$returnHash{$role} = $res->{$role};
 				}
 			}
-			# also return contributor_display.name
-			$returnHash{'display_artist'} = $res->{'contributor_display.name'} if $res->{'contributor_display.name'};
+			my $da = $res->{'tcd.name'} || $res->{'acd.name'};
+			$returnHash{display_artist} = $da if $da;
 		}
 		elsif ( $tag eq 'S' ) {
 			for my $role ( @contributorRoles ) {
@@ -6400,9 +6400,15 @@ sub _getTagDataForTracks {
 	};
 
 	my $join_contributor_display = sub {
-		if ( $sql !~ /JOIN contributor_display/ ) {
+		if ( $sql !~ /JOIN contributor_display AS acd/ ) {
 			$join_albums->();
-			$sql .= 'LEFT JOIN contributor_display ON albums.display_contributor = contributor_display.id ';
+			$sql .= 'LEFT JOIN contributor_display AS acd ON albums.display_contributor = acd.id ';
+		}
+	};
+
+	my $join_track_contributor_display = sub {
+		if ( $sql !~ /JOIN contributor_display AS tcd/ ) {
+			$sql .= 'LEFT JOIN contributor_display AS tcd ON tracks.display_contributor = tcd.id ';
 		}
 	};
 
@@ -6512,7 +6518,9 @@ sub _getTagDataForTracks {
 		$join_contributors->();
 		$c->{'contributors.name'} = 1 if $tags =~ /a/;
 		$join_contributor_display->();
-		$c->{'contributor_display.name'} = 1;
+		$join_track_contributor_display->();
+		$c->{'acd.name'} = 1;
+		$c->{'tcd.name'} = 1;
 
 		# only albums on which the contributor has a specific role?
 		my @roles;
@@ -6672,7 +6680,8 @@ sub _getTagDataForTracks {
 			utf8::decode( $c->{'tracks.lyrics'} ) if exists $c->{'tracks.lyrics'};
 			utf8::decode( $c->{'albums.title'} ) if exists $c->{'albums.title'};
 			utf8::decode( $c->{'contributors.name'} ) if exists $c->{'contributors.name'};
-			utf8::decode( $c->{'contributor_display.name'} ) if exists $c->{'contributor_display.name'};
+			utf8::decode( $c->{'acd.name'} ) if exists $c->{'acd.name'};
+			utf8::decode( $c->{'tcd.name'} ) if exists $c->{'tcd.name'};
 			utf8::decode( $c->{'genres.name'} ) if exists $c->{'genres.name'};
 			utf8::decode( $c->{'comments.value'} ) if exists $c->{'comments.value'};
 			utf8::decode( $c->{'tracks.discsubtitle'}) if exists $c->{'tracks.discsubtitle'};

--- a/Slim/Plugin/FullTextSearch/Plugin.pm
+++ b/Slim/Plugin/FullTextSearch/Plugin.pm
@@ -35,7 +35,8 @@ use constant SQL_CREATE_TRACK_ITEM => q{
 		UNIQUE_TOKENS(LOWER(IFNULL(tracks.title, '')) || ' ' || IFNULL(tracks.titlesearch, '') || ' ' || IFNULL(tracks.customsearch, '')),
 		-- weight 5
 		UNIQUE_TOKENS(IFNULL(tracks.year, '') || ' ' || GROUP_CONCAT(albums.title, ' ') || ' ' || GROUP_CONCAT(albums.titlesearch, ' ') || ' '
-			|| GROUP_CONCAT(genres.name, ' ') || ' ' || GROUP_CONCAT(genres.namesearch, ' ')),
+			|| GROUP_CONCAT(genres.name, ' ') || ' ' || GROUP_CONCAT(genres.namesearch, ' ') || ' '
+			|| IFNULL(tcd.name, '') || ' ' || IFNULL(acd.name, '')),
 		-- weight 3 - contributors create multiple hits, therefore only w3
 		UNIQUE_TOKENS(CONCAT_CONTRIBUTOR_ROLE(tracks.id, GROUP_CONCAT(contributor_track.contributor, ','), 'contributor_track') || ' '
 			|| IGNORE_CASE(comments.value) || ' ' || IGNORE_CASE(tracks.lyrics) || ' ' || IFNULL(tracks.content_type, '') || ' '
@@ -52,6 +53,8 @@ use constant SQL_CREATE_TRACK_ITEM => q{
 		LEFT JOIN genre_track ON genre_track.track = tracks.id
 		LEFT JOIN genres ON genres.id = genre_track.genre
 		LEFT JOIN comments ON comments.track = tracks.id
+		LEFT JOIN contributor_display AS acd ON albums.display_contributor = acd.id
+		LEFT JOIN contributor_display AS tcd ON tracks.display_contributor = tcd.id
 
 		%s
 
@@ -112,7 +115,7 @@ use constant SQL_CREATE_ALBUM_ITEM => qq{
 		UNIQUE_TOKENS(LOWER(IFNULL(albums.title, '')) || ' ' || IFNULL(albums.titlesearch, '') || ' ' || IFNULL(albums.customsearch, '') || ' '
 		|| IFNULL((SELECT GROUP_CONCAT(wt,' ') FROM (SELECT DISTINCT works.titlesearch wt FROM tracks JOIN works ON tracks.work = works.id WHERE tracks.album = albums.id) ), ' ') ),
 		-- weight 5
-		IFNULL(albums.year, ''),
+		UNIQUE_TOKENS(IFNULL(albums.year, '') || ' ' || IFNULL(contributor_display.name, '')),
 		-- weight 3
 		UNIQUE_TOKENS(CONCAT_CONTRIBUTOR_ROLE(albums.id, GROUP_CONCAT(contributor_album.contributor, ','), 'contributor_album')),
 		-- weight 1
@@ -122,6 +125,7 @@ use constant SQL_CREATE_ALBUM_ITEM => qq{
 		FROM albums
 		LEFT JOIN contributor_album ON contributor_album.album = albums.id
 		LEFT JOIN contributors ON contributors.id = contributor_album.contributor
+		LEFT JOIN contributor_display ON albums.display_contributor = contributor_display.id
 
 		%s
 

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -2020,6 +2020,24 @@ sub updateOrCreateBase {
 			$attributeHash = { %{Slim::Formats->readTags($url)}, %$attributeHash  };
 		}
 
+		my $albumDisplayArtist;
+		if ( $attributeHash->{ALBUMARTIST} ) {
+			$albumDisplayArtist = ref $attributeHash->{ALBUMARTIST} eq 'ARRAY'
+				? $attributeHash->{ALBUMARTIST}->[0]
+				: $attributeHash->{ALBUMARTIST};
+		} elsif ( $attributeHash->{ALBUMARTISTS} && ref $attributeHash->{ALBUMARTISTS} eq 'ARRAY' ) {
+			$albumDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ALBUMARTISTS}});
+		}
+
+		my $trackDisplayArtist;
+		if ( $attributeHash->{ARTIST} ) {
+			$trackDisplayArtist = ref $attributeHash->{ARTIST} eq 'ARRAY'
+				? $attributeHash->{ARTIST}->[0]
+				: $attributeHash->{ARTIST};
+		} elsif ( $attributeHash->{ARTISTS} && ref $attributeHash->{ARTISTS} eq 'ARRAY' ) {
+			$trackDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ARTISTS}});
+		}
+
 		my $deferredAttributes;
 		($attributeHash, $deferredAttributes) = $self->_preCheckAttributes({
 			'url'        => $url,
@@ -2070,9 +2088,11 @@ sub updateOrCreateBase {
 		if (!$playlist) {
 
 			$self->_postCheckAttributes({
-				'track'      => $track,
-				'attributes' => $deferredAttributes,
-				'integrateRemote' => $integrateRemote
+				'track'              => $track,
+				'attributes'         => $deferredAttributes,
+				'integrateRemote'    => $integrateRemote,
+				'albumDisplayArtist' => $albumDisplayArtist,
+				'trackDisplayArtist' => $trackDisplayArtist,
 			});
 		}
 
@@ -3049,6 +3069,9 @@ sub _postCheckAttributes {
 	my $attributes = $args->{'attributes'};
 	my $create     = $args->{'create'} || 0;
 
+	my $albumDisplayArtist = $args->{'albumDisplayArtist'};
+	my $trackDisplayArtist = $args->{'trackDisplayArtist'};
+
 	# Don't bother with directories / lnks. This makes sure "No Artist",
 	# etc don't show up if you don't have any.
 	my %cols = $track->get_columns;
@@ -3090,6 +3113,13 @@ sub _postCheckAttributes {
 		$cols{primary_artist} = $artist->[0];
 	}
 
+	my $aaDisplayID = $self->_getOrCreateDisplayContributor($albumDisplayArtist);
+	my $taDisplayID = $self->_getOrCreateDisplayContributor($trackDisplayArtist);
+
+	if ($taDisplayID) {
+		$track->set_column('display_contributor', $taDisplayID);
+	}
+
 	#Work
 	if (defined $attributes->{'WORK'}) {
 		if ( _workRequired($attributes->{'GENRE'}) ) {
@@ -3109,10 +3139,12 @@ sub _postCheckAttributes {
 	my $albumId = $self->_createOrUpdateAlbum($attributes,
 		\%cols,																	# trackColumns
 		$isCompilation,
-		$artist->[0],	                                          # primary contributor-id
+		$artist->[0],															# primary contributor-id
 		defined $contributors->{'ALBUMARTIST'}->[0] ? 1 : 0,					# hasAlbumArtist
 		$create,																# create
 		$track,																	# Track
+		undef,																	# basename
+		$aaDisplayID,
 	);
 
 	# Don't add an album to container tracks - See bug 2337
@@ -3120,7 +3152,7 @@ sub _postCheckAttributes {
 		$track->album($albumId);
 	}
 
-	$self->_createContributorRoleRelationships($contributors, $trackId, $albumId);
+	$self->_createContributorRoleRelationships($contributors, $trackId, $albumId, $aaDisplayID, $taDisplayID);
 
 	# Save any changes - such as album.
 	$track->update;

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -1708,15 +1708,22 @@ sub _newTrack {
 		$LAST_ERROR = 'Track is DRM-protected';
 		return;
 	}
-	if ( $attributeHash->{ALBUMARTIST} && $attributeHash->{ALBUMARTISTS} ) {
-		my $temp = $attributeHash->{ALBUMARTISTS};
-		$attributeHash->{ALBUMARTISTS} = $attributeHash->{ALBUMARTIST};
-		$attributeHash->{ALBUMARTIST} = $temp;
+	my $albumDisplayArtist;
+	if ( $attributeHash->{ALBUMARTIST} ) {
+		$albumDisplayArtist = ref $attributeHash->{ALBUMARTIST} eq 'ARRAY'
+			? $attributeHash->{ALBUMARTIST}->[0]
+			: $attributeHash->{ALBUMARTIST};
+	} elsif ( $attributeHash->{ALBUMARTISTS} && ref $attributeHash->{ALBUMARTISTS} eq 'ARRAY' ) {
+		$albumDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ALBUMARTISTS}});
 	}
-	if ( $attributeHash->{ARTIST} && $attributeHash->{ARTISTS} ) {
-		my $temp = $attributeHash->{ARTISTS};
-		$attributeHash->{ARTISTS} = $attributeHash->{ARTIST};
-		$attributeHash->{ARTIST} = $temp;
+
+	my $trackDisplayArtist;
+	if ( $attributeHash->{ARTIST} ) {
+		$trackDisplayArtist = ref $attributeHash->{ARTIST} eq 'ARRAY'
+			? $attributeHash->{ARTIST}->[0]
+			: $attributeHash->{ARTIST};
+	} elsif ( $attributeHash->{ARTISTS} && ref $attributeHash->{ARTISTS} eq 'ARRAY' ) {
+		$trackDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ARTISTS}});
 	}
 	($attributeHash, $deferredAttributes) = $self->_preCheckAttributes({
 		'url'        => $url,
@@ -1804,12 +1811,14 @@ sub _newTrack {
 	# Walk through the valid contributor roles, adding them to the database.
 	my $contributors = $self->_mergeAndCreateContributors($deferredAttributes, $isCompilation, 1);
 
-	my $aaDisplayID = $self->_getOrCreateDisplayContributor($deferredAttributes->{ALBUMARTISTS});
+	my $aaDisplayID = $self->_getOrCreateDisplayContributor($albumDisplayArtist);
+	my $taDisplayID = $self->_getOrCreateDisplayContributor($trackDisplayArtist);
 
 	# Set primary_artist for the track
 	if ( my $artist = $contributors->{ARTIST} || $contributors->{TRACKARTIST} ) {
 		$columnValueHash{primary_artist} = $artist->[0];
 	}
+	$columnValueHash{display_contributor} = $taDisplayID if $taDisplayID;
 
 	### Create Work rows
 	my $workID;
@@ -1855,7 +1864,7 @@ sub _newTrack {
 	$trackId = $self->_createTrack(\%columnValueHash, \%persistentColumnValueHash, $source);
 
 	### Create ContributorTrack & ContributorAlbum rows
-	$self->_createContributorRoleRelationships($contributors, $trackId, $albumId, $aaDisplayID);
+	$self->_createContributorRoleRelationships($contributors, $trackId, $albumId, $aaDisplayID, $taDisplayID);
 
 	### Create Genre rows
 	$self->_createGenre($deferredAttributes->{'GENRE'}, $trackId, 1);

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -1804,18 +1804,7 @@ sub _newTrack {
 	# Walk through the valid contributor roles, adding them to the database.
 	my $contributors = $self->_mergeAndCreateContributors($deferredAttributes, $isCompilation, 1);
 
-	my $aaDisplayID;
-	if ( $deferredAttributes->{ALBUMARTISTS} ) {
-		my $contributor_display_sth = $self->dbh->prepare_cached('SELECT id FROM contributor_display WHERE name = ?');
-		$contributor_display_sth->execute($deferredAttributes->{ALBUMARTISTS});
-		($aaDisplayID) = $contributor_display_sth->fetchrow_array;
-		$contributor_display_sth->finish;
-		if ( !$aaDisplayID ) {
-			my $sth_insert = $self->dbh->prepare_cached("INSERT INTO contributor_display (name) VALUES (?)");
-			$sth_insert->execute( $deferredAttributes->{ALBUMARTISTS} );
-			$aaDisplayID = $self->dbh->last_insert_id(undef, undef, undef, undef);
-		}
-	}
+	my $aaDisplayID = $self->_getOrCreateDisplayContributor($deferredAttributes->{ALBUMARTISTS});
 
 	# Set primary_artist for the track
 	if ( my $artist = $contributors->{ARTIST} || $contributors->{TRACKARTIST} ) {
@@ -3215,6 +3204,28 @@ sub _mergeAndCreateContributors {
 	}
 
 	return \%contributors;
+}
+
+sub _getOrCreateDisplayContributor {
+	my ($self, $displayName) = @_;
+	return unless defined $displayName && $displayName ne '';
+
+	my $sth = $self->dbh->prepare_cached(
+		'SELECT id FROM contributor_display WHERE name = ?'
+	);
+	$sth->execute($displayName);
+	my ($id) = $sth->fetchrow_array;
+	$sth->finish;
+
+	if (!$id) {
+		my $insert = $self->dbh->prepare_cached(
+			'INSERT INTO contributor_display (name) VALUES (?)'
+		);
+		$insert->execute($displayName);
+		$id = $self->dbh->last_insert_id(undef, undef, undef, undef);
+	}
+
+	return $id;
 }
 
 sub _createContributorRoleRelationships {

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -3190,6 +3190,18 @@ sub _mergeAndCreateContributors {
 		}
 	}
 
+	if ( $prefs->get('usePluralArtistTags') ) {
+		for my $pair ( ['ALBUMARTISTS', 'ALBUMARTIST'], ['ARTISTS', $attributes->{TRACKARTIST} ? 'TRACKARTIST' : 'ARTIST'] ) {
+			my ($plural, $singular) = @$pair;
+			next unless $attributes->{$plural} && ref $attributes->{$plural} eq 'ARRAY';
+
+			my @individuals = grep { defined $_ && $_ ne '' } @{$attributes->{$plural}};
+			next unless @individuals;
+
+			$attributes->{$singular} = \@individuals;
+		}
+	}
+
 	my %contributors = ();
 
 	for my $tag (Slim::Schema::Contributor->contributorRoles) {

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -1713,8 +1713,10 @@ sub _newTrack {
 		$albumDisplayArtist = ref $attributeHash->{ALBUMARTIST} eq 'ARRAY'
 			? $attributeHash->{ALBUMARTIST}->[0]
 			: $attributeHash->{ALBUMARTIST};
-	} elsif ( $attributeHash->{ALBUMARTISTS} && ref $attributeHash->{ALBUMARTISTS} eq 'ARRAY' ) {
-		$albumDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ALBUMARTISTS}});
+	} elsif ( $attributeHash->{ALBUMARTISTS} ) {
+		$albumDisplayArtist = ref $attributeHash->{ALBUMARTISTS} eq 'ARRAY'
+			? join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ALBUMARTISTS}})
+			: $attributeHash->{ALBUMARTISTS};
 	}
 
 	my $trackDisplayArtist;
@@ -1722,8 +1724,10 @@ sub _newTrack {
 		$trackDisplayArtist = ref $attributeHash->{ARTIST} eq 'ARRAY'
 			? $attributeHash->{ARTIST}->[0]
 			: $attributeHash->{ARTIST};
-	} elsif ( $attributeHash->{ARTISTS} && ref $attributeHash->{ARTISTS} eq 'ARRAY' ) {
-		$trackDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ARTISTS}});
+	} elsif ( $attributeHash->{ARTISTS} ) {
+		$trackDisplayArtist = ref $attributeHash->{ARTISTS} eq 'ARRAY'
+			? join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ARTISTS}})
+			: $attributeHash->{ARTISTS};
 	}
 	($attributeHash, $deferredAttributes) = $self->_preCheckAttributes({
 		'url'        => $url,
@@ -2025,8 +2029,10 @@ sub updateOrCreateBase {
 			$albumDisplayArtist = ref $attributeHash->{ALBUMARTIST} eq 'ARRAY'
 				? $attributeHash->{ALBUMARTIST}->[0]
 				: $attributeHash->{ALBUMARTIST};
-		} elsif ( $attributeHash->{ALBUMARTISTS} && ref $attributeHash->{ALBUMARTISTS} eq 'ARRAY' ) {
-			$albumDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ALBUMARTISTS}});
+		} elsif ( $attributeHash->{ALBUMARTISTS} ) {
+			$albumDisplayArtist = ref $attributeHash->{ALBUMARTISTS} eq 'ARRAY'
+				? join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ALBUMARTISTS}})
+				: $attributeHash->{ALBUMARTISTS};
 		}
 
 		my $trackDisplayArtist;
@@ -2034,8 +2040,10 @@ sub updateOrCreateBase {
 			$trackDisplayArtist = ref $attributeHash->{ARTIST} eq 'ARRAY'
 				? $attributeHash->{ARTIST}->[0]
 				: $attributeHash->{ARTIST};
-		} elsif ( $attributeHash->{ARTISTS} && ref $attributeHash->{ARTISTS} eq 'ARRAY' ) {
-			$trackDisplayArtist = join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ARTISTS}});
+		} elsif ( $attributeHash->{ARTISTS} ) {
+			$trackDisplayArtist = ref $attributeHash->{ARTISTS} eq 'ARRAY'
+				? join(', ', grep { defined $_ && $_ ne '' } @{$attributeHash->{ARTISTS}})
+				: $attributeHash->{ARTISTS};
 		}
 
 		my $deferredAttributes;
@@ -3193,9 +3201,10 @@ sub _mergeAndCreateContributors {
 	if ( $prefs->get('usePluralArtistTags') ) {
 		for my $pair ( ['ALBUMARTISTS', 'ALBUMARTIST'], ['ARTISTS', $attributes->{TRACKARTIST} ? 'TRACKARTIST' : 'ARTIST'] ) {
 			my ($plural, $singular) = @$pair;
-			next unless $attributes->{$plural} && ref $attributes->{$plural} eq 'ARRAY';
+			next unless defined $attributes->{$plural};
 
-			my @individuals = grep { defined $_ && $_ ne '' } @{$attributes->{$plural}};
+			my @individuals = grep { defined $_ && $_ ne '' }
+				Slim::Music::Info::splitTag($attributes->{$plural});
 			next unless @individuals;
 
 			$attributes->{$singular} = \@individuals;

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -3271,7 +3271,7 @@ sub _getOrCreateDisplayContributor {
 
 sub _createContributorRoleRelationships {
 
-	my ($self, $contributors, $trackId, $albumId, $aaDisplayID) = @_;
+	my ($self, $contributors, $trackId, $albumId, $aaDisplayID, $taDisplayID) = @_;
 
 	if (!keys %$contributors) {
 		main::DEBUGLOG && $log->debug('Attempt to set empty contributor set for trackid=', $trackId);
@@ -3318,6 +3318,13 @@ sub _createContributorRoleRelationships {
 		(?, ?, ?)
 	} ) if $aaDisplayID;
 
+	my $sth_track_display = $self->dbh->prepare_cached( qq{
+		REPLACE INTO contributor_track_display
+		(contributor_display, contributor, track)
+		VALUES
+		(?, ?, ?)
+	} ) if $taDisplayID;
+
 	while (my ($role, $contributorList) = each %{$contributors}) {
 		my $roleId = Slim::Schema::Contributor->typeToRole($role);
 		for my $contributor (@{$contributorList}) {
@@ -3330,6 +3337,9 @@ sub _createContributorRoleRelationships {
 			$sth_album->execute( $roleId, $contributor, $albumId );
 			if ( $aaDisplayID && $role eq 'ALBUMARTIST' ) {
 				$sth_album_display->execute( $aaDisplayID, $contributor, $albumId );
+			}
+			if ( $taDisplayID && ($role eq 'ARTIST' || $role eq 'TRACKARTIST') ) {
+				$sth_track_display->execute( $taDisplayID, $contributor, $trackId );
 			}
 		}
 	}

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -411,7 +411,7 @@ sub init {
 
 	$prefs->setChange(
 		sub { Slim::Control::Request::executeRequest(undef, ['wipecache', $prefs->get('dontTriggerScanOnPrefChange') ? 'queue' : undef]) },
-		qw(splitList groupdiscs useTPE2AsAlbumArtist useTIT1AsWork cleanupReleaseTypes worksScan)
+		qw(splitList groupdiscs useTPE2AsAlbumArtist useTIT1AsWork cleanupReleaseTypes worksScan usePluralArtistTags)
 	);
 
 	$prefs->setChange( sub {

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -173,6 +173,7 @@ sub init {
 		'autoDownloadUpdate'    => sub { $os->canAutoUpdate() },
 		'noGenreFilter'         => 0,
 		'noRoleFilter'          => 0,
+		'usePluralArtistTags'   => 0,
 		'searchSubString'       => 0,
 		'ignoredarticles'       => "The El La Los Las Le Les",
 		'splitList'             => ';',

--- a/Slim/Web/Settings/Server/Behavior.pm
+++ b/Slim/Web/Settings/Server/Behavior.pm
@@ -31,7 +31,7 @@ sub prefs {
 				ignoreReleaseTypes cleanupReleaseTypes groupArtistAlbumsByReleaseType
 				useTPE2AsAlbumArtist variousArtistsString ratingImplementation useUnifiedArtistsList
 				skipsentinel showComposerReleasesbyAlbum myClassicalGenres onlyAlbumYears
-				worksScan useTIT1AsWork)
+				worksScan useTIT1AsWork usePluralArtistTags)
 		   );
 }
 

--- a/strings.txt
+++ b/strings.txt
@@ -8707,7 +8707,7 @@ SETUP_USEPLURALARTISTTAGS
 	EN	Use Plural Artist Tags
 
 SETUP_USEPLURALARTISTTAGS_DESC
-	EN	When enabled, the scanner uses ALBUMARTISTS and ARTISTS tags (plural) as the authoritative source for individual contributors. This produces clean contributor entries without joined display strings. Requires a rescan after changing. Tags written by Picard, SongKong, and other modern taggers are supported.
+	EN	When your music files contain both a display name (e.g. ALBUMARTIST = "John Lennon & Yoko Ono") and a list of individual artists (ALBUMARTISTS/ARTISTS tags), LMS normally creates a single artist entry from the display name. Enable this setting to use the individual artist list instead, so each artist gets their own entry in the library. The display name is still shown in the UI. Requires a rescan after changing. Most taggers (Picard, SongKong, Mp3tag) can write these tags.
 
 SETUP_USEPLURALARTISTTAGS_0
 	EN	Disabled

--- a/strings.txt
+++ b/strings.txt
@@ -8703,6 +8703,18 @@ SETUP_NOROLEFILTER_DESC
 	SV	När du bläddrar genom "Artister" kan du filtrera så att bara album och låtar som matchar den valda rollen ("ALBUMARTIST", "COMPOSER", etc.) visas.
 	ZH_CN	在浏览艺术家时，可以过滤并只显示和所选角色匹配的专辑和音轨（例如，ALBUMARTIST，COMPOSER等）。
 
+SETUP_USEPLURALARTISTTAGS
+	EN	Use Plural Artist Tags
+
+SETUP_USEPLURALARTISTTAGS_DESC
+	EN	When enabled, the scanner uses ALBUMARTISTS and ARTISTS tags (plural) as the authoritative source for individual contributors. This produces clean contributor entries without joined display strings. Requires a rescan after changing. Tags written by Picard, SongKong, and other modern taggers are supported.
+
+SETUP_USEPLURALARTISTTAGS_0
+	EN	Disabled
+
+SETUP_USEPLURALARTISTTAGS_1
+	EN	Enabled
+
 SETUP_ROLESINARTISTS
 	CS	Interpret skladby, Skladatel, Skupina a Orchestr v Interpretech
 	DA	Nummerets kunstner, Komponist, band og orkester i Kunstnere


### PR DESCRIPTION
## Summary

Ports the functional display_artist changes onto your 3NF contributor_display schema, as discussed in PR #20.

- **Replace tag swap with capture-before-defer:** extracts display strings from ALBUMARTIST/ARTIST without mutating tag values. Fixes scenario 3 data loss.
- **Rescan path:** updateOrCreateBase and _postCheckAttributes now populate display_contributor on track update, not just fresh scan.
- **Track-level display:** populates tracks.display_contributor and contributor_track_display junction table for ARTIST/TRACKARTIST roles. Queries return track-level display_artist via aliased JOINs.
- **Preference gate:** usePluralArtistTags (default OFF). When ON, ALBUMARTISTS/ARTISTS entries replace singular tags for contributor creation.
- **FTS indexing:** display names indexed in fulltext search via contributor_display JOINs.
- **Helper extraction:** _getOrCreateDisplayContributor reuses the lookup/insert pattern across _newTrack, _postCheckAttributes, and both album/track paths.

Schema is untouched. All changes work with your contributor_display table, integer FK columns, and junction tables as-is.

Supersedes #20 (flat-column approach).

## Test plan

- [ ] Fresh scan with pref OFF: contributor_display populated, albums.display_contributor set, API returns display_artist
- [ ] Fresh scan with pref ON: individual contributors created from plural tags, no joined-string contributor rows
- [ ] Rescan after retag: display_contributor updates on existing tracks
- [ ] FTS search for display string (e.g. "Chick Corea & Gary Burton") finds album
- [ ] Smoketest and verifyStrings pass