### PR TITLE
Move SQLite function registration to `SQLiteHelper`

### DIFF
--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -136,8 +136,6 @@ sub init {
 		exit;
 	};
 
-	Slim::Utils::OSDetect->getOS()->sqlHelperClass()->addPostConnectHandler($class);
-
 	if (Slim::Utils::OSDetect->getOS()->sqlHelperClass()->canCacheDBHandle()) {
 		$_dbh = $dbh;
 	}
@@ -3394,32 +3392,6 @@ sub _workRequired {
 	return $prefs->get('worksScan') == SCAN_WORKS_FOR_MY_CLASSICAL_GENRES
 		? Slim::Schema::Genre->isMyClassicalGenre($genres)
 		: $prefs->get('worksScan');
-}
-
-sub _folderUrlFromPath {
-	my ($path) = @_;
-
-	return Slim::Utils::Misc::fileURLFromPath(dirname($path));
-}
-
-sub _folderFromPath {
-	my ($path) = @_;
-
-	return dirname($path);
-}
-
-sub _folderFromURL {
-	my ($url) = @_;
-
-	return dirname(Slim::Utils::Misc::pathFromfileURL($url));
-}
-
-sub postDBConnect {
-	my ($class, $dbh) = @_;
-
-	$dbh->sqlite_create_function( 'FOLDER_URL_FROM_PATH', 1, \&_folderUrlFromPath );
-	$dbh->sqlite_create_function( 'FOLDER_FROM_PATH', 1, \&_folderFromPath );
-	$dbh->sqlite_create_function( 'FOLDER_FROM_URL', 1, \&_folderFromURL );
 }
 
 =head1 SEE ALSO

--- a/Slim/Utils/Misc.pm
+++ b/Slim/Utils/Misc.pm
@@ -335,6 +335,17 @@ sub fileURLFromPath {
 	return $file;
 }
 
+sub folderURLFromPath {
+	my ($path) = @_;
+	return fileURLFromPath(dirname($path));
+}
+
+sub folderFromURL {
+	my ($url) = @_;
+	return dirname(pathFromfileURL($url));
+}
+
+
 ########
 
 # other people call us externally.

--- a/Slim/Utils/SQLiteHelper.pm
+++ b/Slim/Utils/SQLiteHelper.pm
@@ -23,7 +23,7 @@ Slim::Utils::SQLiteHelper->init
 use strict;
 
 use Digest::MD5 qw(md5_hex);
-use File::Basename;
+use File::Basename qw(basename dirname);
 use File::Path;
 use File::Slurp;
 use File::Spec::Functions qw(catfile);
@@ -338,7 +338,10 @@ my %postConnectHandlers;
 sub postConnect {
 	my ( $class, $dbh ) = @_;
 
-	$dbh->func( 'MD5', 1, sub { md5_hex( $_[0] ) }, 'create_function' );
+	$dbh->sqlite_create_function( 'MD5', 1, sub { md5_hex( $_[0] ) });
+	$dbh->sqlite_create_function( 'FOLDER_URL_FROM_PATH', 1, \&Slim::Utils::Misc::folderURLFromPath );
+	$dbh->sqlite_create_function( 'FOLDER_FROM_PATH', 1, \&dirname );
+	$dbh->sqlite_create_function( 'FOLDER_FROM_URL', 1, \&Slim::Utils::Misc::folderFromURL );
 
 	# We create this even if main::STATISTICS is not false so that the SQL always works
 	# Track Persistent data is in another file, in the prefs folder rather than cache


### PR DESCRIPTION
I'm sorry for this PR on top of your PR on top of my PR... but I didn't get your branch to run on my machine without this change. And I think those additional helpers might come in handy in other places anyway.

The other way somehow failed scans on my machine. I wasn't able to run the scanner without this modification on my dev Mac.

I hope to have more feedback for your PR soon - thanks for the patience!